### PR TITLE
fix: correct covid-19 post path

### DIFF
--- a/content/posts/Divers/covid-19.md
+++ b/content/posts/Divers/covid-19.md
@@ -1,5 +1,5 @@
 ---
-path: "/docker-mac"
+path: "/covid-19"
 date: "2020-12-30T19:07:33.962Z"
 title: "Covid 19 🦠 - Q/R "
 blogImage: "https://photos.lci.fr/images/1280/720/covid-19-coronavirus-virus-illustration-2089fa-0@1x.jpeg"


### PR DESCRIPTION
## Summary
- Fix incorrect `path` frontmatter in `content/posts/Divers/covid-19.md` (`/docker-mac` → `/covid-19`)

## Test plan
- [x] Run `npm run develop` and verify the Covid-19 post is reachable at `/covid-19`

🤖 Generated with [Claude Code](https://claude.com/claude-code)