### PR TITLE
fix: auto-reload page on service worker update

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -20,3 +20,5 @@ export const wrapRootElement = ({ element }) => {
 
     return ConnectedRootElement
 }
+
+export const onServiceWorkerUpdateReady = () => window.location.reload()


### PR DESCRIPTION
## Summary
- Add `onServiceWorkerUpdateReady` hook in `gatsby-browser.js` to auto-reload the page when a new service worker version is available
- Fixes stale cached assets persisting in users' browsers after a deploy (caused by `gatsby-plugin-offline`)

## Test plan
- [x] Deploy, visit the site, deploy again with a visible change, then revisit — the page should reload automatically and show the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)