### PR TITLE
feat: draft posts (published flag, dev visible / prod hidden)

### DIFF
--- a/content/posts/JS/content_test.md
+++ b/content/posts/JS/content_test.md
@@ -3,6 +3,7 @@ path: "/hello-world2"
 date: "2017-07-12T17:12:33.962Z"
 title: "I like nonsense, it wakes up the brain cells "
 category: "toto"
+published: false
 blogImage: "https://gatsby-starter-hero-blog.greglobinski.com/static/photo-1507915600431-5292809c5ab7-40d4f4de1973c24726e4ef65ef5fd03e-f16ff.jpg"
 ---
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -36,6 +36,7 @@ const query = `{
             path
             category
             title
+            published
           }
       image: frontmatter { blogImage}
       fields {
@@ -50,10 +51,14 @@ const query = `{
 }`;
 
 //transformer pour mapper les données dans algolia
+//Les posts marqués `published: false` ne doivent jamais finir dans l'index (sinon recherche → 404).
 const queries = [
   {
     query,
-    transformer: ({ data }) => data.allMarkdownRemark.edges.map(({ node }) => node), // optional
+    transformer: ({ data }) =>
+      data.allMarkdownRemark.edges
+        .map(({ node }) => node)
+        .filter(node => node.frontmatter.published !== false),
     indexName: 'wulfy_blog', // overrides main index name, optional
   },
 ];

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -29,6 +29,21 @@ if (ALGOLIA_API_ID && ALGOLIA_API_KEY && ALGOLIA_INDEX_NAME) {
   index = client.initIndex(ALGOLIA_INDEX_NAME);
 }
 
+const isProduction = process.env.NODE_ENV === 'production'
+
+//Déclare le champ `published` du frontmatter pour qu'il soit toujours présent dans le schéma,
+//même si aucun post ne le définit encore (sinon les requêtes GraphQL le sélectionnant échouent).
+exports.createSchemaCustomization = ({ actions }) => {
+  actions.createTypes(`
+    type MarkdownRemarkFrontmatter {
+      published: Boolean
+    }
+    type MarkdownRemark implements Node {
+      frontmatter: MarkdownRemarkFrontmatter
+    }
+  `)
+}
+
 //When you implement a Gatsby API, you're passed a collection of "Bound Action Creators"
 // (functions which create and dispatch Redux actions when called) which you can use to manipulate state on your site.
 //The object actions contains the functions and these can be individually extracted by using ES6 object destructuring.
@@ -103,6 +118,7 @@ exports.createPages = ({ actions, graphql }) => {
                 frontmatter {
                   path
                   category
+                  published
                 }
               }
             }
@@ -114,6 +130,10 @@ exports.createPages = ({ actions, graphql }) => {
         }
 
         result.data.allMarkdownRemark.edges.forEach(({ node }) => {
+          //En prod on n'expose pas les pages des posts non publiés (404 plutôt qu'une URL accessible).
+          if (isProduction && node.frontmatter.published === false) {
+            return;
+          }
           const category = node.fields.defaultCategory ? node.fields.defaultCategory : node.frontmatter.category;
           const type = node.fields.type ;
           createPage({

--- a/src/pages/category.js
+++ b/src/pages/category.js
@@ -11,17 +11,24 @@ const Category = props => {
     pageContext: { category },
   } = props
 
+    const isProduction = process.env.NODE_ENV === 'production'
+    const visiblePosts = isProduction
+      ? posts.filter(({ node }) => node.frontmatter.published !== false)
+      : posts
+
     let postsList = []
-    const postByCats = _.groupBy(posts, ({node}) => node.fields.defaultCategory ? node.fields.defaultCategory : node.frontmatter.category);
+    const postByCats = _.groupBy(visiblePosts, ({node}) => node.fields.defaultCategory ? node.fields.defaultCategory : node.frontmatter.category);
     _.forEach(postByCats, (posts, currentCategory) => {
       if(category && category !== currentCategory)
       {
         return;
       }
       const postsListItems = posts.reduce((acc, { node: { frontmatter, fields } }) => {
+        const isDraft = frontmatter.published === false
         acc.push(
           <li key={frontmatter.title}>
             <Link to={`${fields.slug}`}>{frontmatter.title}</Link>
+            {isDraft && <i className="fas fa-times" style={{ color: 'red', marginLeft: '8px' }} title="Not published" />}
           </li>
         )
         return acc
@@ -73,6 +80,7 @@ export const categoryQuery = graphql`
             path
             category
             title
+            published
           }
         }
       }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -52,17 +52,25 @@ class IndexPage extends React.Component {
   	didMount can't do it because it is fired AFTER rendering and it
   	calculate the total height (so it needs to have all elements already rendered  ) */
 
+    const isProduction = process.env.NODE_ENV === 'production'
+    //En prod les posts non publiés sont retirés. En dev ils restent visibles avec un marqueur.
+    const visiblePosts = isProduction
+      ? posts.filter(({ node }) => node.frontmatter.published !== false)
+      : posts
+
     let catList = []
     let postsList = []
-    const postByCats = _.groupBy(posts, ({node}) => node.fields.defaultCategory ? node.fields.defaultCategory : node.frontmatter.category);//TODO: regroup this funtion and others bellow to have same code for cat AND index
+    const postByCats = _.groupBy(visiblePosts, ({node}) => node.fields.defaultCategory ? node.fields.defaultCategory : node.frontmatter.category);//TODO: regroup this funtion and others bellow to have same code for cat AND index
     const categories = []
     _.forEach(postByCats, (posts, category) => {
       categories.push(category)
       const categoryImage = getCatImage(category)
       const postsListItems = posts.reduce((acc, { node: { frontmatter, fields } }) => {
+        const isDraft = frontmatter.published === false
         acc.push(
           <li key={frontmatter.title}>
             <Link to={`${fields.slug}`}>{frontmatter.title}</Link>
+            {isDraft && <i className="fas fa-times" style={{ color: 'red', marginLeft: '8px' }} title="Not published" />}
           </li>
         )
         return acc
@@ -192,6 +200,7 @@ export const categoryQuery = graphql`
             path
             category
             title
+            published
           }
         }
       }

--- a/src/pages/postOrPage.js
+++ b/src/pages/postOrPage.js
@@ -10,18 +10,25 @@ const PostOrPage = props => {
     pageContext: { category },
   } = props
 
+    const isProduction = process.env.NODE_ENV === 'production'
+    const visiblePosts = isProduction
+      ? posts.filter(({ node }) => node.frontmatter.published !== false)
+      : posts
+
     let postsList = []
     console.log(posts);
-    const postByCats = _.groupBy(posts, ({node}) => node.fields.defaultCategory ? node.fields.defaultCategory : node.frontmatter.category);
+    const postByCats = _.groupBy(visiblePosts, ({node}) => node.fields.defaultCategory ? node.fields.defaultCategory : node.frontmatter.category);
     _.forEach(postByCats, (posts, currentCategory) => {
       if(category && category !== currentCategory)
       {
         return;
       }
       const postsListItems = posts.reduce((acc, { node: { frontmatter, fields } }) => {
+        const isDraft = frontmatter.published === false
         acc.push(
           <li key={frontmatter.title}>
             <Link to={`${fields.slug}`}>{frontmatter.title}</Link>
+            {isDraft && <i className="fas fa-times" style={{ color: 'red', marginLeft: '8px' }} title="Not published" />}
           </li>
         )
         return acc
@@ -71,6 +78,7 @@ export const postOrPageQuery = graphql`
             path
             category
             title
+            published
           }
         }
       }

--- a/src/templates/posts.js
+++ b/src/templates/posts.js
@@ -9,6 +9,17 @@ import Layout from '../components/layout'
 import Disqus from '../components/disqus'
 
 //https://www.gatsbyjs.org/tutorial/part-seven/#creating-slugs-for-pages
+const notPublishedBannerStyle = {
+  display: 'inline-block',
+  marginTop: '8px',
+  padding: '4px 10px',
+  background: '#d32f2f',
+  color: '#fff',
+  fontWeight: 'bold',
+  fontStyle: 'normal',
+  borderRadius: '3px',
+}
+
 export default ({ data,pathContext,location }) => {
   const { markdownRemark: post } = data
   const postImg = post.frontmatter.blogImage ? post.frontmatter.blogImage : DEFAULT_POST_IMG;
@@ -17,6 +28,8 @@ export default ({ data,pathContext,location }) => {
     backgroundPosition: "center",
     backgroundSize: "cover",
   }
+  //En prod cette page n'est pas générée pour les drafts, le badge est donc une aide visuelle de dev.
+  const showDraftBadge = process.env.NODE_ENV !== 'production' && post.frontmatter.published === false
   console.log("re render posts");
   return (
     <Layout location={location}>
@@ -27,6 +40,11 @@ export default ({ data,pathContext,location }) => {
             <div className="post_metas">
               <h1 className="post_title meta">{post.frontmatter.title}</h1>
               <i className="post_date meta"> <i className="fas fa-calendar-alt"></i>  {post.frontmatter.date}</i>
+              {showDraftBadge && (
+                <div>
+                  <span style={notPublishedBannerStyle}>Not published</span>
+                </div>
+              )}
             </div>
             <div
               className="blog-post-content"
@@ -58,6 +76,7 @@ export const pageQuery = graphql`
         path
         title
         blogImage
+        published
       }
     }
   }


### PR DESCRIPTION
## Summary
Adds support for marking a post as a draft via a `published: false` frontmatter flag, without deleting it.

- **In production** the post is fully hidden:
  - no detail page generated (`gatsby-node.js` createPages skips it)
  - excluded from homepage, category and type listings
  - excluded from the Algolia index (otherwise it would still appear in search and 404 on click)
- **In development** the post stays visible with two visual cues:
  - red **"Not published"** badge under the date in the post page
  - red cross (`fa-times`) next to the title in every listing

The `published` field is declared via `createSchemaCustomization` so the GraphQL schema knows it exists even when no post sets it yet.

## Usage
Add `published: false` to a post frontmatter:
```yaml
---
path: "/my-post"
title: "..."
published: false
---
```

## Test plan
- [x] `npm run develop` with one post marked `published: false` → red badge under the date, red cross next to the title in homepage / category / type listings
- [x] `npm run build && npm run serve` → the draft post returns 404, no listing references it, no Algolia index entry

## Notes
- The interpretation chosen for "croix rouge en fin de menu" is one cross per draft post (after each title), not a single cross at the end of the list — feel free to adjust if you wanted the other reading.
- Style is inline (`#d32f2f` red badge, red `fa-times` icon) matching the codebase's inline-style convention; can be moved to CSS later if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)