### PR TITLE
fix(algolia): properly remove stale records from the index

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -26,12 +26,19 @@ const oldquery = `{
 }`;
 
 //query utilisée pour remonter les infos à Algolia
+//`internal.contentDigest` est requis : gatsby-plugin-algolia s'en sert
+//comme marker "ce record est géré par moi", et n'efface pas les records
+//qui ne l'ont pas. Sans ce champ, les posts retirés de la query restent
+//en stale dans l'index.
 const query = `{
  allMarkdownRemark {
    edges {
      node {
       objectID: id
       html
+      internal {
+        contentDigest
+      }
       frontmatter {
             path
             category

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -3,9 +3,6 @@
  *
  * See: https://www.gatsbyjs.org/docs/node-apis/
  */
-const ALGOLIA_API_ID = process.env.ALGOLIA_API_ID;
-const ALGOLIA_API_KEY = process.env.ALGOLIA_API_KEY;
-const ALGOLIA_INDEX_NAME = process.env.ALGOLIA_INDEX_NAME;
 
 const _ = require('lodash')
 
@@ -20,14 +17,6 @@ const getComponent = type =>
     ? path.resolve(`src/templates/${type}.js`)
     : path.resolve(`src/templates/pages.js`)
 
-
-// Only initialize Algolia if credentials are provided
-let client, index;
-if (ALGOLIA_API_ID && ALGOLIA_API_KEY && ALGOLIA_INDEX_NAME) {
-  const algoliasearch = require('algoliasearch');
-  client = algoliasearch(ALGOLIA_API_ID, ALGOLIA_API_KEY);
-  index = client.initIndex(ALGOLIA_INDEX_NAME);
-}
 
 const isProduction = process.env.NODE_ENV === 'production'
 
@@ -166,9 +155,3 @@ exports.createPages = ({ actions, graphql }) => {
   })//end promise
 }
 
-//empty algolia search to prevent double posts declaration
-exports.onPreBuild = () => {
-  if (index) {
-    index.clearObjects();
-  }
-}


### PR DESCRIPTION
## Problem
Posts removed from the Algolia query (e.g. via the upcoming `published: false` flag in #66, or simply deleted) were staying in the Algolia index forever, leading to search results pointing at 404 URLs.

## Root cause
1. **Missing `internal.contentDigest` in the query.** `gatsby-plugin-algolia` uses that field as a "managed by me" marker. In `fetchExistingObjects`/the diff loop, records without it are skipped from the deletion candidate list. As long as our query didn't select it, the plugin would happily upload fresh records but never delete the stale ones.
2. **`index.clearObjects()` in `onPreBuild` was fire-and-forget.** No `await`/`return` of the Promise, so it raced with the plugin's upload phase. It was also a workaround for issue (1) — once (1) is fixed, this hack is redundant and harmful.

## Changes
- `gatsby-config.js`: add `internal { contentDigest }` to the Algolia query selection
- `gatsby-node.js`: remove the `onPreBuild` hook and the now-unused Algolia client initialization

## Migration note (⚠️ workaround needed once)
Records uploaded by previous builds do **not** have `internal.contentDigest`. The plugin's diff logic ignores them, so the first build after this PR **will not delete them automatically**. They must be deleted manually from the Algolia dashboard once. From the second build onwards (and for any future unpublish), the cleanup is automatic.

## Test plan
- [x] Manually delete the stale draft record in the Algolia dashboard
- [x] Trigger a Coolify build → verify only published posts appear in the index
- [x] Mark another post `published: false` and trigger a build → verify it's removed from Algolia automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)